### PR TITLE
Fix the even-numbered district headings

### DIFF
--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -85,10 +85,10 @@
               {{ $c3 := len $at_large }}
               {{ $count := len $districts_to_show }}
               
-              <!-- all districts: {{ string $c1 }} -->
-              <!-- this district: {{ string $c2 }} -->
-              <!-- at large: {{ string $c3 }} -->
-              <!-- to show: {{ string $count }} -->
+              <div> all districts: {{ string $c1 }} </div>
+              <div> this district: {{ string $c2 }} </div>
+              <div> at large: {{ string $c3 }} </div>
+              <div> to show: {{ string $count }} </div>
 
               {{ if gt $count 0 }}
               

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -76,20 +76,10 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "not in" (slice "Oakland City Council" "AC Transit Board of Directors" "BART Board of Directors") }}
             <div>
-              {{ $districts := (.Pages.GroupByParam "district") }}
-              {{ $this_district := (where $districts .Key "eq" $.Page.Params.District) }}
-              {{ $at_large := (where $districts .Key "eq" "At-Large") }}
-              {{ $districts_to_show := ($at_large | append $this_district) }}
-              {{ $c1 := len $districts }}
-              {{ $c2 := len $this_district }}
-              {{ $c3 := len $at_large }}
-              {{ $count := len $districts_to_show }}
-              
-              <div> all districts: {{ string $c1 }} </div>
-              <div> this district: {{ string $c2 }} </div>
-              <div> at large: {{ string $c3 }} </div>
+              {{ $districts := where (.Pages.GroupByParam "district") ".Key" "in" (slice $.Page.Params.District "At-Large") }}
+              {{ $count := len $districts }}
               <div> to show: {{ string $count }} </div>
-
+              
               {{ if gt $count 0 }}
               
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -57,8 +57,8 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "==" "BART Board of Directors" }}
             <div>
-              {{ $districts_to_show := (where (.Pages.GroupByParam "district") .Params.district "in" $.Page.Params.bart_districts) }}
-              {{ if gt (len $districts_to_show) 0 }}
+              {{ $districts_to_show := (where (.Pages.GroupByParam "district") .Key "in" $.Page.Params.bart_districts) }}
+              {{ if (gt (len $districts_to_show) 0) }}
               <h3>{{ .Key }}</h3>
                 <div>
                   {{ range (.Pages.GroupByParam "district") }}
@@ -83,7 +83,7 @@
               {{ $this_district := (where $districts .Key "eq" $.Page.Params.District) }}
               {{ $at_large := (where $districts .Key "eq" "At-Large") }}
               {{ $districts_to_show := (append $at_large $this_district) }}
-              {{ if gt (len $districts_to_show) 0 }}
+              {{ if (gt (len $districts_to_show) 0) }}
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->
                 <div>
                   {{ range (.Pages.GroupByParam "district") }}

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -57,6 +57,9 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "==" "BART Board of Directors" }}
             <div>
+              {{ $districts := where (.Pages.GroupByParam "district") ".Key" "in" $.Page.Params.bart_districts }}
+              {{ $count := len $districts }}
+              {{ if gt $count 0 }}
               <h3>{{ .Key }}</h3>
                 <div>
                   {{ range (.Pages.GroupByParam "district") }}
@@ -72,14 +75,13 @@
                   {{ end }}
                   {{ end }}
                 </div>
+              {{ end }}
             </div>
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "not in" (slice "Oakland City Council" "AC Transit Board of Directors" "BART Board of Directors") }}
             <div>
               {{ $districts := where (.Pages.GroupByParam "district") ".Key" "in" (slice $.Page.Params.District "At-Large") }}
               {{ $count := len $districts }}
-              <div> to show: {{ string $count }} </div>
-              
               {{ if gt $count 0 }}
               
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -57,8 +57,6 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "==" "BART Board of Directors" }}
             <div>
-              {{ $districts_to_show := (where (.Pages.GroupByParam "district") .Key "in" $.Page.Params.bart_districts) }}
-              {{ if (gt (len $districts_to_show) 0) }}
               <h3>{{ .Key }}</h3>
                 <div>
                   {{ range (.Pages.GroupByParam "district") }}
@@ -74,7 +72,6 @@
                   {{ end }}
                   {{ end }}
                 </div>
-              {{ end }}
             </div>
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "not in" (slice "Oakland City Council" "AC Transit Board of Directors" "BART Board of Directors") }}
@@ -82,8 +79,9 @@
               {{ $districts := (.Pages.GroupByParam "district") }}
               {{ $this_district := (where $districts .Key "eq" $.Page.Params.District) }}
               {{ $at_large := (where $districts .Key "eq" "At-Large") }}
-              {{ $districts_to_show := (append $at_large $this_district) }}
+              {{ $districts_to_show := ($at_large append $this_district) }}
               {{ if (gt (len $districts_to_show) 0) }}
+              
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->
                 <div>
                   {{ range (.Pages.GroupByParam "district") }}
@@ -99,6 +97,7 @@
                   {{ end }}
                   {{ end }}
                 </div>
+              
               {{ end }}
             </div>
             {{ end }}

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -57,7 +57,7 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "==" "BART Board of Directors" }}
             <div>
-              {{ $districts_to_show := (where (.Pages.GroupByParam "district") .Key in $.Page.Params.bart_districts) }}
+              {{ $districts_to_show := (where (.Pages.GroupByParam "district") .Key in ($.Page.Params.bart_districts)) }}
               {{ if gt (len $districts_to_show) 0 }}
               <h3>{{ .Key }}</h3>
                 <div>

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -80,7 +80,17 @@
               {{ $this_district := (where $districts .Key "eq" $.Page.Params.District) }}
               {{ $at_large := (where $districts .Key "eq" "At-Large") }}
               {{ $districts_to_show := ($at_large | append $this_district) }}
-              {{ if (gt (len $this_district) 0) }}
+              {{ $c1 := len $districts }}
+              {{ $c2 := len $this_district }}
+              {{ $c3 := len $at_large }}
+              {{ $count := len $districts_to_show }}
+              
+              <!-- all districts: {{ string $c1 }} -->
+              <!-- this district: {{ string $c2 }} -->
+              <!-- at large: {{ string $c3 }} -->
+              <!-- to show: {{ string $count }} -->
+
+              {{ if gt $count 0 }}
               
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->
                 <div>

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -57,7 +57,7 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "==" "BART Board of Directors" }}
             <div>
-              {{ $districts_to_show := where (.Pages.GroupByParam "district") .Key in $.Page.Params.bart_districts) }}
+              {{ $districts_to_show := (where (.Pages.GroupByParam "district") .Key in $.Page.Params.bart_districts) }}
               {{ if gt (len $districts_to_show) 0 }}
               <h3>{{ .Key }}</h3>
                 <div>

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -80,7 +80,8 @@
               {{ $this_district := (where $districts .Key "eq" $.Page.Params.District) }}
               {{ $at_large := (where $districts .Key "eq" "At-Large") }}
               {{ $districts_to_show := ($at_large | append $this_district) }}
-              {{ if (gt (len $districts_to_show) 0) }}
+              <!-- {{ if (gt (len $districts_to_show) 0) }} -->
+              {{ if (gt (len $this_district) 0) }}
               
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->
                 <div>

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -80,7 +80,6 @@
               {{ $this_district := (where $districts .Key "eq" $.Page.Params.District) }}
               {{ $at_large := (where $districts .Key "eq" "At-Large") }}
               {{ $districts_to_show := ($at_large | append $this_district) }}
-              <!-- {{ if (gt (len $districts_to_show) 0) }} -->
               {{ if (gt (len $this_district) 0) }}
               
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -77,8 +77,8 @@
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "not in" (slice "Oakland City Council" "AC Transit Board of Directors" "BART Board of Directors") }}
             <div>
               {{ $districts := (where .Pages.GroupByParam "district") }}
-              {{ $this_district := (where $districts .Key == $.Page.Params.District) }}
-              {{ $at_large := (where $districts .Key == "At-Large") }}
+              {{ $this_district := (where $districts .Key "==" $.Page.Params.District) }}
+              {{ $at_large := (where $districts .Key "==" "At-Large") }}
               {{ $districts_to_show := (append $at_large $this_district) }}
               {{ $districts_to_show_count := len $districts_to_show }}
               {{ if gt $districts_to_show_count 0 }}

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -79,7 +79,7 @@
               {{ $districts := (.Pages.GroupByParam "district") }}
               {{ $this_district := (where $districts .Key "eq" $.Page.Params.District) }}
               {{ $at_large := (where $districts .Key "eq" "At-Large") }}
-              {{ $districts_to_show := ($at_large append $this_district) }}
+              {{ $districts_to_show := ($at_large | append $this_district) }}
               {{ if (gt (len $districts_to_show) 0) }}
               
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -76,7 +76,7 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "not in" (slice "Oakland City Council" "AC Transit Board of Directors" "BART Board of Directors") }}
             <div>
-              {{ $districts := (where .Pages.GroupByParam "district") }}
+              {{ $districts := (where (.Pages.GroupByParam "district") .Key) }}
               {{ $this_district := (where $districts .Key "==" $.Page.Params.District) }}
               {{ $at_large := (where $districts .Key "==" "At-Large") }}
               {{ $districts_to_show := (append $at_large $this_district) }}

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -57,7 +57,7 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "==" "BART Board of Directors" }}
             <div>
-              {{ $districts_to_show := (where (.Pages.GroupByParam "district") .Key "in" ($.Page.Params.bart_districts)) }}
+              {{ $districts_to_show := (where (.Pages.GroupByParam "district") .Params.district "in" $.Page.Params.bart_districts) }}
               {{ if gt (len $districts_to_show) 0 }}
               <h3>{{ .Key }}</h3>
                 <div>

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -80,8 +80,8 @@
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "not in" (slice "Oakland City Council" "AC Transit Board of Directors" "BART Board of Directors") }}
             <div>
               {{ $districts := (.Pages.GroupByParam "district") }}
-              {{ $this_district := (where $districts .Key eq $.Page.Params.District) }}
-              {{ $at_large := (where $districts .Key eq "At-Large") }}
+              {{ $this_district := (where $districts .Key "eq" $.Page.Params.District) }}
+              {{ $at_large := (where $districts .Key "eq" "At-Large") }}
               {{ $districts_to_show := (append $at_large $this_district) }}
               {{ if gt (len $districts_to_show) 0 }}
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -57,7 +57,7 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "==" "BART Board of Directors" }}
             <div>
-              {{ $districts_to_show := (where (.Pages.GroupByParam "district") .Key in ($.Page.Params.bart_districts)) }}
+              {{ $districts_to_show := (where (.Pages.GroupByParam "district") .Key "in" ($.Page.Params.bart_districts)) }}
               {{ if gt (len $districts_to_show) 0 }}
               <h3>{{ .Key }}</h3>
                 <div>

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -76,7 +76,7 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "not in" (slice "Oakland City Council" "AC Transit Board of Directors" "BART Board of Directors") }}
             <div>
-              {{ $districts := (where (.Pages.GroupByParam "district") .Key) }}
+              {{ $districts := (.Pages.GroupByParam "district") }}
               {{ $this_district := (where $districts .Key "==" $.Page.Params.District) }}
               {{ $at_large := (where $districts .Key "==" "At-Large") }}
               {{ $districts_to_show := (append $at_large $this_district) }}

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -57,6 +57,8 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "==" "BART Board of Directors" }}
             <div>
+              {{ $districts_to_show := where (.Pages.GroupByParam "district") .Key in $.Page.Params.bart_districts) }}
+              {{ if gt (len $districts_to_show) 0 }}
               <h3>{{ .Key }}</h3>
                 <div>
                   {{ range (.Pages.GroupByParam "district") }}
@@ -72,16 +74,16 @@
                   {{ end }}
                   {{ end }}
                 </div>
+              {{ end }}
             </div>
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "not in" (slice "Oakland City Council" "AC Transit Board of Directors" "BART Board of Directors") }}
             <div>
               {{ $districts := (.Pages.GroupByParam "district") }}
-              {{ $this_district := (where $districts .Key "==" $.Page.Params.District) }}
-              {{ $at_large := (where $districts .Key "==" "At-Large") }}
+              {{ $this_district := (where $districts .Key eq $.Page.Params.District) }}
+              {{ $at_large := (where $districts .Key eq "At-Large") }}
               {{ $districts_to_show := (append $at_large $this_district) }}
-              {{ $districts_to_show_count := len $districts_to_show }}
-              {{ if gt $districts_to_show_count 0 }}
+              {{ if gt (len $districts_to_show) 0 }}
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->
                 <div>
                   {{ range (.Pages.GroupByParam "district") }}

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -76,11 +76,17 @@
             {{ end }}
             {{ range where (.Data.Pages.GroupByParam "Office") ".Key" "not in" (slice "Oakland City Council" "AC Transit Board of Directors" "BART Board of Directors") }}
             <div>
-              <h3>{{ .Key }}</h3>
+              {{ $districts := (where .Pages.GroupByParam "district") }}
+              {{ $this_district := (where $districts .Key == $.Page.Params.District) }}
+              {{ $at_large := (where $districts .Key == "At-Large") }}
+              {{ $districts_to_show := (append $at_large $this_district) }}
+              {{ $districts_to_show_count := len $districts_to_show }}
+              {{ if gt len($districts_to_show) 0 }}
+              <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->
                 <div>
                   {{ range (.Pages.GroupByParam "district") }}
                   {{ if (or (eq .Key $.Page.Params.District) (eq .Key "At-Large"))}}
-                    <h4>District: {{ .Key }}</h4>
+                    <h4>District: {{ .Key }}</h4> <!-- e.g., District: 4 -->
                     <div class="row filtr-container">
                       {{ range (.Pages)}}
                         <div class="col-lg-4 col-sm-6 filtr-item">
@@ -91,6 +97,7 @@
                   {{ end }}
                   {{ end }}
                 </div>
+              {{ end }}
             </div>
             {{ end }}
           {{ end }}

--- a/layouts/guide/single.html
+++ b/layouts/guide/single.html
@@ -81,7 +81,7 @@
               {{ $at_large := (where $districts .Key == "At-Large") }}
               {{ $districts_to_show := (append $at_large $this_district) }}
               {{ $districts_to_show_count := len $districts_to_show }}
-              {{ if gt len($districts_to_show) 0 }}
+              {{ if gt $districts_to_show_count 0 }}
               <h3>{{ .Key }}</h3> <!-- e.g., OUSD School Board Director -->
                 <div>
                   {{ range (.Pages.GroupByParam "district") }}


### PR DESCRIPTION
References, because this has been a journey:
* https://gohugo.io/templates/introduction/
* https://gohugo.io/functions/where/
* https://gohugo.io/functions/len/
* https://gohugo.io/functions/union/
* https://gohugo.io/functions/string/

When debugging, you seemingly cannot print things inside of `<!-- ... -->` but must use divs or whatever.